### PR TITLE
test doesn't segfault now on my machine but bench still does.

### DIFF
--- a/benches/fiat_field.rs
+++ b/benches/fiat_field.rs
@@ -14,8 +14,13 @@ pub fn bench_pluto_fiat_field(c: &mut Criterion) {
         0xe5,
     ]);
 
-    let a = Fp::random(&mut rng);
-    let b = Fp::random(&mut rng);
+    // Tried to hardcode the inputs to some that worked in the test,
+    // but bench still segfaults using asm version.
+    let a = Fp([9727937518965806870, 17997379296386006080, 15768176054952429141, 16030199860960463994, 16461039066468101070, 15473669141602183867, 1284300730483519534]); 
+    let b = Fp([11900058621813723661, 12194876775783740577, 12052811721051170045, 14225122879085785230, 15158554168614662472, 2622749211587325692, 1835628996346027802]);
+
+    //let a = Fp::random(&mut rng);
+    //let b = Fp::random(&mut rng);
 
     let mg_a = montgomery_domain_field_element(a.0);
     let mg_b = montgomery_domain_field_element(b.0);

--- a/src/pluto_eris/fields/assembly.rs
+++ b/src/pluto_eris/fields/assembly.rs
@@ -18,13 +18,14 @@
 use std::arch::asm;
 
 //#[cfg(target_arch = "x86_64")]
-pub fn mul_asm(arg1: &[u64; 7], arg2: &[u64; 7]) -> [u64; 7] {
+pub fn mul_asm(out: &mut [u64;7], arg1: &[u64; 7], arg2: &[u64; 7]) {
     let r_in1 = *arg1;
     let mut r_in2 = *arg2;
-    let mut r_out: [u64; 7] = [0, 0, 0, 0, 0, 0, 0];
+    let mut r_out: &mut[u64; 7] = out;//[0, 0, 0, 0, 0, 0, 0];
 
     unsafe {
         asm!(
+            // "nop",
             "sub rsp, 1288",
             "mov rax, rdx",
             "mov rdx, [ rdx + 0x0 ]",
@@ -123,11 +124,11 @@ pub fn mul_asm(arg1: &[u64; 7], arg2: &[u64; 7]) -> [u64; 7] {
             "mov r13, 0xe4a7a5fe8fadffd6",
             "xchg rdx, r12",
             "mov [ rsp + 0x70 ], r14",
-            "mov byte [ rsp + 0x78 ], r8b",
+            "mov byte ptr [ rsp + 0x78 ], r8b",
             "mulx r8, r14, r13",
             "adcx r14, rdi",
             "mov rdi, 0x443f9a5cda8a6c7b",
-            "mov byte [ rsp + 0x80 ], r11b",
+            "mov byte ptr [ rsp + 0x80 ], r11b",
             "mulx r11, r13, rdi",
             "mov rdi, rdx",
             "mov rdx, [ rax + 0x10 ]",
@@ -219,7 +220,7 @@ pub fn mul_asm(arg1: &[u64; 7], arg2: &[u64; 7]) -> [u64; 7] {
             "mulx r9, r12, [ rsi + 0x10 ]",
             "mov rdx, 0x130e0000d7f70e4",
             "mov [ rsp + 0xf8 ], r15",
-            "mov byte [ rsp + 0x100 ], r10b",
+            "mov byte ptr [ rsp + 0x100 ], r10b",
             "mulx r10, r15, rdi",
             "mov rdx, [ rax + 0x0 ]",
             "mov [ rsp + 0x108 ], r12",
@@ -261,7 +262,7 @@ pub fn mul_asm(arg1: &[u64; 7], arg2: &[u64; 7]) -> [u64; 7] {
             "mulx r15, r12, [ rax + 0x30 ]",
             "mov rdx, [ rsi + 0x20 ]",
             "mov [ rsp + 0x168 ], r14",
-            "mov byte [ rsp + 0x170 ], bpl",
+            "mov byte ptr [ rsp + 0x170 ], bpl",
             "mulx rbp, r14, [ rax + 0x20 ]",
             "adcx r9, [ rsp + 0x0 ]",
             "seto dl",
@@ -284,7 +285,7 @@ pub fn mul_asm(arg1: &[u64; 7], arg2: &[u64; 7]) -> [u64; 7] {
             "mulx r9, rbp, [ rsi + 0x20 ]",
             "setc dl",
             "mov [ rsp + 0x180 ], rdi",
-            "movzx rdi, byte [ rsp + 0x80 ]",
+            "movzx rdi, byte ptr [ rsp + 0x80 ]",
             "clc",
             "mov [ rsp + 0x188 ], r8",
             "mov r8, -0x1",
@@ -296,7 +297,7 @@ pub fn mul_asm(arg1: &[u64; 7], arg2: &[u64; 7]) -> [u64; 7] {
             "mulx r12, r8, [ rsi + 0x30 ]",
             "adox rbp, rcx",
             "seto dl",
-            "movzx rcx, byte [ rsp + 0x78 ]",
+            "movzx rcx, byte ptr [ rsp + 0x78 ]",
             "mov [ rsp + 0x198 ], rbp",
             "mov rbp, -0x1",
             "inc rbp",
@@ -329,7 +330,7 @@ pub fn mul_asm(arg1: &[u64; 7], arg2: &[u64; 7]) -> [u64; 7] {
             "lea rdx, [ rdx + r11 ]",
             "mov r11, [ rsp + 0x168 ]",
             "setc bl",
-            "movzx r14, byte [ rsp + 0x170 ]",
+            "movzx r14, byte ptr [ rsp + 0x170 ]",
             "clc",
             "mov rcx, -0x1",
             "adcx r14, rcx",
@@ -365,7 +366,7 @@ pub fn mul_asm(arg1: &[u64; 7], arg2: &[u64; 7]) -> [u64; 7] {
             "adcx rdi, [ rsp + 0x158 ]",
             "mov r10b, dl",
             "mov rdx, [ rsi + 0x10 ]",
-            "mov byte [ rsp + 0x1f8 ], bl",
+            "mov byte ptr [ rsp + 0x1f8 ], bl",
             "mulx rbx, r15, [ rax + 0x20 ]",
             "adox rbp, [ rsp + 0x10 ]",
             "adcx r15, r13",
@@ -448,7 +449,7 @@ pub fn mul_asm(arg1: &[u64; 7], arg2: &[u64; 7]) -> [u64; 7] {
             "adcx r10, [ rsp + 0x148 ]",
             "mov rdi, [ rsp - 0x30 ]",
             "setc r11b",
-            "movzx rbp, byte [ rsp + 0x100 ]",
+            "movzx rbp, byte ptr [ rsp + 0x100 ]",
             "clc",
             "mov r8, -0x1",
             "adcx rbp, r8",
@@ -500,7 +501,7 @@ pub fn mul_asm(arg1: &[u64; 7], arg2: &[u64; 7]) -> [u64; 7] {
             "mulx r13, r12, r10",
             "mov r10, 0xa803ca76f439266f",
             "mov [ rsp + 0x298 ], r13",
-            "mov byte [ rsp + 0x2a0 ], r14b",
+            "mov byte ptr [ rsp + 0x2a0 ], r14b",
             "mulx r14, r13, r10",
             "adox r13, r15",
             "mov r15, 0x130e0000d7f70e4",
@@ -520,7 +521,7 @@ pub fn mul_asm(arg1: &[u64; 7], arg2: &[u64; 7]) -> [u64; 7] {
             "mov [ rsp + 0x2b0 ], r12",
             "mulx r12, r14, r15",
             "mov r15, 0x9ffffcd300000001",
-            "mov byte [ rsp + 0x2b8 ], r13b",
+            "mov byte ptr [ rsp + 0x2b8 ], r13b",
             "mov [ rsp + 0x2c0 ], r10",
             "mulx r10, r13, r15",
             "mov r15, 0xa803ca76f439266f",
@@ -562,9 +563,9 @@ pub fn mul_asm(arg1: &[u64; 7], arg2: &[u64; 7]) -> [u64; 7] {
             "adcx r13, [ rsp + 0x280 ]",
             "mov r8, [ rsp + 0x278 ]",
             "adcx r8, [ rsp + 0x270 ]",
-            "movzx r9, byte [ rsp + 0x1f8 ]",
+            "movzx r9, byte ptr [ rsp + 0x1f8 ]",
             "seto cl",
-            "movzx rdi, byte [ rsp + 0x2a0 ]",
+            "movzx rdi, byte ptr [ rsp + 0x2a0 ]",
             "mov [ rsp + 0x2e8 ], r14",
             "mov r14, -0x1",
             "inc r14",
@@ -631,7 +632,7 @@ pub fn mul_asm(arg1: &[u64; 7], arg2: &[u64; 7]) -> [u64; 7] {
             "adox rdi, [ rsp + 0x2e8 ]",
             "mov rcx, 0x2400000000002400",
             "mov rdx, r14",
-            "mov byte [ rsp + 0x318 ], r10b",
+            "mov byte ptr [ rsp + 0x318 ], r10b",
             "mulx r10, r14, rcx",
             "adcx rdi, [ rsp + 0x128 ]",
             "setc cl",
@@ -647,7 +648,7 @@ pub fn mul_asm(arg1: &[u64; 7], arg2: &[u64; 7]) -> [u64; 7] {
             "mulx r10, r15, r12",
             "mov r12, 0x9ffffcd300000001",
             "mov [ rsp + 0x328 ], r14",
-            "mov byte [ rsp + 0x330 ], cl",
+            "mov byte ptr [ rsp + 0x330 ], cl",
             "mulx rcx, r14, r12",
             "mov r12, 0xa2a7e8c30006b945",
             "mov [ rsp + 0x338 ], r10",
@@ -670,10 +671,10 @@ pub fn mul_asm(arg1: &[u64; 7], arg2: &[u64; 7]) -> [u64; 7] {
             "mulx r13, rdi, rbp",
             "mov r13, 0x9ffffcd300000001",
             "xchg rdx, rdi",
-            "mov byte [ rsp + 0x350 ], r14b",
+            "mov byte ptr [ rsp + 0x350 ], r14b",
             "mulx r14, rbp, r13",
             "mov r13, 0xe4a7a5fe8fadffd6",
-            "mov byte [ rsp + 0x358 ], r12b",
+            "mov byte ptr [ rsp + 0x358 ], r12b",
             "mov [ rsp + 0x360 ], r14",
             "mulx r14, r12, r13",
             "mov r13, 0xa2a7e8c30006b945",
@@ -689,7 +690,7 @@ pub fn mul_asm(arg1: &[u64; 7], arg2: &[u64; 7]) -> [u64; 7] {
             "movzx rcx, cl",
             "adcx rcx, r15",
             "adcx rbx, [ rsp + 0x2c0 ]",
-            "movzx rcx, byte [ rsp + 0x2b8 ]",
+            "movzx rcx, byte ptr [ rsp + 0x2b8 ]",
             "mov r15, [ rsp + 0x298 ]",
             "lea rcx, [ rcx + r15 ]",
             "adcx r9, [ rsp + 0x2b0 ]",
@@ -712,12 +713,12 @@ pub fn mul_asm(arg1: &[u64; 7], arg2: &[u64; 7]) -> [u64; 7] {
             "adcx r14, [ rsp + 0x360 ]",
             "mov rdi, 0x443f9a5cda8a6c7b",
             "mov [ rsp + 0x380 ], r14",
-            "mov byte [ rsp + 0x388 ], r8b",
+            "mov byte ptr [ rsp + 0x388 ], r8b",
             "mulx r8, r14, rdi",
             "adcx r12, [ rsp + 0x370 ]",
             "movzx rdi, r15b",
             "mov [ rsp + 0x390 ], r12",
-            "movzx r12, byte [ rsp + 0x318 ]",
+            "movzx r12, byte ptr [ rsp + 0x318 ]",
             "lea rdi, [ rdi + r12 ]",
             "adcx r14, [ rsp + 0x368 ]",
             "adox rdi, [ rsp + 0x1b8 ]",
@@ -725,8 +726,8 @@ pub fn mul_asm(arg1: &[u64; 7], arg2: &[u64; 7]) -> [u64; 7] {
             "mov [ rsp + 0x398 ], r14",
             "mulx r14, r15, r12",
             "seto r12b",
-            "mov byte [ rsp + 0x3a0 ], r13b",
-            "movzx r13, byte [ rsp + 0x358 ]",
+            "mov byte ptr [ rsp + 0x3a0 ], r13b",
+            "movzx r13, byte ptr [ rsp + 0x358 ]",
             "mov [ rsp + 0x3a8 ], r14",
             "mov r14, -0x1",
             "inc r14",
@@ -743,7 +744,7 @@ pub fn mul_asm(arg1: &[u64; 7], arg2: &[u64; 7]) -> [u64; 7] {
             "mulx r14, r8, r10",
             "mov rdx, 0x443f9a5cda8a6c7b",
             "mov [ rsp + 0x3b0 ], r15",
-            "mov byte [ rsp + 0x3b8 ], r12b",
+            "mov byte ptr [ rsp + 0x3b8 ], r12b",
             "mulx r12, r15, r10",
             "seto dl",
             "mov [ rsp + 0x3c0 ], r14",
@@ -754,7 +755,7 @@ pub fn mul_asm(arg1: &[u64; 7], arg2: &[u64; 7]) -> [u64; 7] {
             "adox r15, [ rsp + 0x338 ]",
             "adox r8, r12",
             "setc r11b",
-            "movzx r12, byte [ rsp + 0x330 ]",
+            "movzx r12, byte ptr [ rsp + 0x330 ]",
             "clc",
             "adcx r12, r14",
             "adcx rbp, [ rsp + 0x120 ]",
@@ -778,7 +779,7 @@ pub fn mul_asm(arg1: &[u64; 7], arg2: &[u64; 7]) -> [u64; 7] {
             "adcx r11, rdi",
             "adcx r10, [ rsp + 0x3a8 ]",
             "movzx r11, r12b",
-            "movzx rdi, byte [ rsp + 0x3b8 ]",
+            "movzx rdi, byte ptr [ rsp + 0x3b8 ]",
             "lea r11, [ r11 + rdi ]",
             "mov rdi, 0x2400000000002400",
             "xchg rdx, rdi",
@@ -789,7 +790,7 @@ pub fn mul_asm(arg1: &[u64; 7], arg2: &[u64; 7]) -> [u64; 7] {
             "mov rcx, 0x0",
             "adox r13, rcx",
             "adc r10, 0x0",
-            "add byte [ rsp + 0x350 ], 0x7F",
+            "add byte ptr [ rsp + 0x350 ], 0x7F",
             "adox rbp, [ rsp + 0x378 ]",
             "adox r15, rbx",
             "mov rbx, -0x1",
@@ -797,7 +798,7 @@ pub fn mul_asm(arg1: &[u64; 7], arg2: &[u64; 7]) -> [u64; 7] {
             "adcx rdi, rbx",
             "adcx r11, [ rsp + 0x1b0 ]",
             "setc dil",
-            "movzx rcx, byte [ rsp + 0x3a0 ]",
+            "movzx rcx, byte ptr [ rsp + 0x3a0 ]",
             "clc",
             "adcx rcx, rbx",
             "adcx rbp, [ rsp + 0x28 ]",
@@ -805,7 +806,7 @@ pub fn mul_asm(arg1: &[u64; 7], arg2: &[u64; 7]) -> [u64; 7] {
             "adcx r15, [ rsp + 0x20 ]",
             "adcx r8, [ rsp + 0x190 ]",
             "setc cl",
-            "movzx r9, byte [ rsp + 0x388 ]",
+            "movzx r9, byte ptr [ rsp + 0x388 ]",
             "clc",
             "adcx r9, rbx",
             "adcx rbp, [ rsp + 0x380 ]",
@@ -834,8 +835,8 @@ pub fn mul_asm(arg1: &[u64; 7], arg2: &[u64; 7]) -> [u64; 7] {
             "mov [ rsp + 0x3f0 ], r12",
             "mulx r12, rbx, r10",
             "mov r10, 0xe4a7a5fe8fadffd6",
-            "mov byte [ rsp + 0x3f8 ], dil",
-            "mov byte [ rsp + 0x400 ], cl",
+            "mov byte ptr [ rsp + 0x3f8 ], dil",
+            "mov byte ptr [ rsp + 0x400 ], cl",
             "mulx rcx, rdi, r10",
             "mov r10, 0x130e0000d7f70e4",
             "mov [ rsp + 0x408 ], r13",
@@ -846,7 +847,7 @@ pub fn mul_asm(arg1: &[u64; 7], arg2: &[u64; 7]) -> [u64; 7] {
             "mov [ rsp + 0x420 ], r14",
             "mulx r14, r11, r10",
             "mov r10, 0xa2a7e8c30006b945",
-            "mov byte [ rsp + 0x428 ], r9b",
+            "mov byte ptr [ rsp + 0x428 ], r9b",
             "mov [ rsp + 0x430 ], r15",
             "mulx r15, r9, r10",
             "seto r10b",
@@ -855,7 +856,7 @@ pub fn mul_asm(arg1: &[u64; 7], arg2: &[u64; 7]) -> [u64; 7] {
             "inc r11",
             "adox r9, r14",
             "mov r14, 0x443f9a5cda8a6c7b",
-            "mov byte [ rsp + 0x440 ], r10b",
+            "mov byte ptr [ rsp + 0x440 ], r10b",
             "mulx r10, r11, r14",
             "adox rdi, r15",
             "adox r11, rcx",
@@ -869,14 +870,14 @@ pub fn mul_asm(arg1: &[u64; 7], arg2: &[u64; 7]) -> [u64; 7] {
             "adox r9, [ rsp + 0x430 ]",
             "mov rbp, [ rsp + 0x420 ]",
             "seto r15b",
-            "movzx r10, byte [ rsp + 0x428 ]",
+            "movzx r10, byte ptr [ rsp + 0x428 ]",
             "inc rcx",
             "mov rcx, -0x1",
             "adox r10, rcx",
             "adox rbp, [ rsp + 0x3b0 ]",
             "mov r10, [ rsp + 0x3d0 ]",
             "seto cl",
-            "movzx r14, byte [ rsp + 0x440 ]",
+            "movzx r14, byte ptr [ rsp + 0x440 ]",
             "mov [ rsp + 0x448 ], r13",
             "mov r13, -0x1",
             "inc r13",
@@ -894,7 +895,7 @@ pub fn mul_asm(arg1: &[u64; 7], arg2: &[u64; 7]) -> [u64; 7] {
             "mov [ rsp + 0x450 ], rbx",
             "mulx rbx, r13, r15",
             "seto dl",
-            "movzx r15, byte [ rsp + 0x400 ]",
+            "movzx r15, byte ptr [ rsp + 0x400 ]",
             "mov [ rsp + 0x458 ], rdi",
             "mov rdi, -0x1",
             "inc rdi",
@@ -940,7 +941,7 @@ pub fn mul_asm(arg1: &[u64; 7], arg2: &[u64; 7]) -> [u64; 7] {
             "sbb r12, r14",
             "movzx r14, dl",
             "mov [ rsp + 0x470 ], r12",
-            "movzx r12, byte [ rsp + 0x3f8 ]",
+            "movzx r12, byte ptr [ rsp + 0x3f8 ]",
             "lea r14, [ r14 + r12 ]",
             "mov r12, [ rsp + 0x1f0 ]",
             "mov rdx, 0x0",
@@ -1017,7 +1018,8 @@ pub fn mul_asm(arg1: &[u64; 7], arg2: &[u64; 7]) -> [u64; 7] {
             "mov r14, [ rsp - 0x60 ]",
             "mov r15, [ rsp - 0x58 ]",
             "add rsp, 1288",
-            "ret",
+            // (The `ret` instruction here seems to cause the tests to segfault.)
+            // "ret",
 
             in("rsi") r_in1.as_ptr(),
             in("rdx") r_in2.as_mut_ptr(),
@@ -1040,7 +1042,8 @@ pub fn mul_asm(arg1: &[u64; 7], arg2: &[u64; 7]) -> [u64; 7] {
         )
     }
 
-    r_out
+    // (fn changed to match mul sig.)
+    // r_out
 }
 
 #[cfg(test)]
@@ -1074,11 +1077,14 @@ pub(crate) mod tests {
         fp_a: &Fp,
         fp_b: &Fp,
     ) {
-        let in1 = mg_a.0;
-        let in2 = mg_b.0;
-        let mg_ret = montgomery_domain_field_element(mul_asm(&in1, &in2));
-        let fp_ret = fp_a.mul(&fp_b);
-        assert_eq!(mg_ret.0, fp_ret.0);
+        let in1 = core::hint::black_box(mg_a);
+        let in2 = core::hint::black_box(mg_b);
+        let mut ret = core::hint::black_box(montgomery_domain_field_element([0;7]));
+        
+        let now = std::time::Instant::now();
+        mul(&mut ret, &in1, &in2);
+        let duration = std::time::Instant::now() - now;
+        println!("duration {:?}", duration);
     }
 
     #[test]

--- a/src/pluto_eris/fields/fp_fiat.rs
+++ b/src/pluto_eris/fields/fp_fiat.rs
@@ -18,6 +18,8 @@
 #![allow(unused_parens)]
 #![allow(non_camel_case_types)]
 
+use super::assembly;
+
 /** u1 represents values of 1 bits, stored in one byte. */
 type u1 = u8;
 /** i1 represents values of 1 bits, stored in one byte. */
@@ -148,6 +150,15 @@ fn cmovznz_u64(out1: &mut u64, arg1: u1, arg2: u64, arg3: u64) {
     *out1 = x3;
 }
 
+#[cfg(feature = "asm")]
+pub fn mul(
+    out1: &mut montgomery_domain_field_element,
+    arg1: &montgomery_domain_field_element,
+    arg2: &montgomery_domain_field_element,
+) {
+    assembly::mul_asm(&mut out1.0, &arg1.0, &arg2.0)
+}
+
 /// The function mul multiplies two field elements in the Montgomery domain.
 ///
 /// Preconditions:
@@ -157,6 +168,7 @@ fn cmovznz_u64(out1: &mut u64, arg1: u1, arg2: u64, arg3: u64) {
 ///   eval (from_montgomery out1) mod m = (eval (from_montgomery arg1) * eval (from_montgomery arg2)) mod m
 ///   0 ≤ eval out1 < m
 ///
+#[cfg(not(feature = "asm"))]
 pub fn mul(
     out1: &mut montgomery_domain_field_element,
     arg1: &montgomery_domain_field_element,


### PR DESCRIPTION
Running these two we see different results from within the test for asm and non-asm versions:

`cargo test pluto_eris::fields::assembly --release --features asm -- --nocapture`

`cargo test pluto_eris::fields::assembly --release -- --nocapture`

On my amd box the rust is faster than the asm by a bit, but consistently. Let me know what happens on your box and if you can spot any glaring issue that invalidates the benchmark.